### PR TITLE
Fixed buffer leak

### DIFF
--- a/parser-library/parse.cpp
+++ b/parser-library/parse.cpp
@@ -1236,6 +1236,7 @@ void DestructParsedPE(parsed_pe *p) {
     return;
   }
 
+  deleteBuffer(p->fileBuffer);
   delete p->internal;
   delete p;
   return;


### PR DESCRIPTION
Added a call to deleteBuffer in DestructParsedPE .
Without the delete, the buffer leaks.
