### PR TITLE
Added share for read, write and delete

### DIFF
--- a/parser-library/buffer.cpp
+++ b/parser-library/buffer.cpp
@@ -117,7 +117,7 @@ bounded_buffer *readFileToFileBuffer(const char *filePath) {
 #ifdef WIN32
   HANDLE  h = CreateFileA(filePath, 
                           GENERIC_READ, 
-                          0, 
+                          FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE, 
                           NULL, 
                           OPEN_EXISTING, 
                           FILE_ATTRIBUTE_NORMAL, 


### PR DESCRIPTION
Opening the file with share enables other processes to use this file while the pe-parse object is still open
